### PR TITLE
Add tool prefix to py.test config

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 testpaths = t
 python_classes = test_*,Test*
 


### PR DESCRIPTION
Py.test 3.0 release deprecated the `[pytest]` header in setup.cfg and instead uses `[tool:pytest]`. This is noted by the following warning:

`WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.`

Also, from the [py.test docs](http://doc.pytest.org/en/latest/customize.html#initialization-determining-rootdir-and-inifile): 

`path/setup.cfg  # must also contain [tool:pytest] section to match`
